### PR TITLE
Support multiple album selection and no album selection modes

### DIFF
--- a/App/Views/App.swift
+++ b/App/Views/App.swift
@@ -1,9 +1,3 @@
-//
-//  App.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/22.
-//
 
 import SwiftUI
 

--- a/App/Views/MacOnboardingView.swift
+++ b/App/Views/MacOnboardingView.swift
@@ -1,9 +1,3 @@
-//
-//  MacOnboardingView.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/05/10.
-//
 
 import Komponents
 import SwiftUI

--- a/App/Views/MacOnboardingView.swift
+++ b/App/Views/MacOnboardingView.swift
@@ -14,6 +14,8 @@ struct MacOnboardingView: View {
     @AppStorage(wrappedValue: true, "ShowSaveAnimation", store: defaults) var showSaveAnimation: Bool
     @AppStorage(wrappedValue: false, "AutoSelectSearch", store: defaults) var autoSelectFirstSearchResult: Bool
     @AppStorage(wrappedValue: false, "AutoOpenKeyboard", store: defaults) var autoOpenKeyboard: Bool
+    @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
+    @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
     @AppStorage(wrappedValue: Data(), "RecentAlbums", store: defaults) var recentAlbumsData: Data
 
     var body: some View {
@@ -109,6 +111,8 @@ struct MacOnboardingView: View {
                     Toggle("Settings.SaveRecents", isOn: $saveRecentAlbums)
                     Toggle("Settings.AutoOpenKeyboard", isOn: $autoOpenKeyboard)
                     Toggle("Settings.AutoSelectFirstSearchResult", isOn: $autoSelectFirstSearchResult)
+                    Toggle("Settings.MultipleAlbumSelection", isOn: $multipleAlbumSelection)
+                    Toggle("Settings.NoAlbumSelection", isOn: $noAlbumSelection)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 .padding()

--- a/App/Views/OnboardingView.swift
+++ b/App/Views/OnboardingView.swift
@@ -14,6 +14,8 @@ struct OnboardingView: View {
     @AppStorage(wrappedValue: true, "ShowSaveAnimation", store: defaults) var showSaveAnimation: Bool
     @AppStorage(wrappedValue: false, "AutoSelectSearch", store: defaults) var autoSelectFirstSearchResult: Bool
     @AppStorage(wrappedValue: false, "AutoOpenKeyboard", store: defaults) var autoOpenKeyboard: Bool
+    @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
+    @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
     @AppStorage(wrappedValue: Data(), "RecentAlbums", store: defaults) var recentAlbumsData: Data
 
     var body: some View {
@@ -55,6 +57,8 @@ struct OnboardingView: View {
                     Toggle("Settings.SaveRecents", isOn: $saveRecentAlbums)
                     Toggle("Settings.AutoOpenKeyboard", isOn: $autoOpenKeyboard)
                     Toggle("Settings.AutoSelectFirstSearchResult", isOn: $autoSelectFirstSearchResult)
+                    Toggle("Settings.MultipleAlbumSelection", isOn: $multipleAlbumSelection)
+                    Toggle("Settings.NoAlbumSelection", isOn: $noAlbumSelection)
                 } header: {
                     ListSectionHeader(text: "Settings.Title")
                 }

--- a/App/Views/OnboardingView.swift
+++ b/App/Views/OnboardingView.swift
@@ -1,9 +1,3 @@
-//
-//  OnboardingView.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/22.
-//
 
 import Komponents
 import SwiftUI

--- a/Bromides.xcodeproj/project.pbxproj
+++ b/Bromides.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.Bromides.Save-to-Album";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -427,7 +427,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.Bromides.Save-to-Album";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -603,7 +603,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.Bromides;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -649,7 +649,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.Bromides;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -683,7 +683,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.Bromides.Share-with-Bromides";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -719,7 +719,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tsubuzaki.Bromides.Share-with-Bromides";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/Extension/Classes/Navigator.swift
+++ b/Extension/Classes/Navigator.swift
@@ -1,9 +1,3 @@
-//
-//  Navigator.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/04/05.
-//
 
 import Foundation
 import Observation

--- a/Extension/Classes/PhotosLibrary.swift
+++ b/Extension/Classes/PhotosLibrary.swift
@@ -1,9 +1,3 @@
-//
-//  PhotosLibrary.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 import Photos
 #if os(macOS)

--- a/Extension/Classes/PhotosLibrary.swift
+++ b/Extension/Classes/PhotosLibrary.swift
@@ -161,6 +161,19 @@ class PhotosLibrary {
         }
     }
 
+    static func saveImage(data: Data) async -> Bool {
+        guard let image = XPImage(data: data) else { return false }
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                PHAssetChangeRequest.creationRequestForAsset(from: image)
+            }
+            return true
+        } catch {
+            debugPrint(error.localizedDescription)
+            return false
+        }
+    }
+
     static func saveImage(data: Data, to album: PHAssetCollection) async -> Bool {
         guard let image = XPImage(data: data) else { return false }
         do {

--- a/Extension/CloseFunction.swift
+++ b/Extension/CloseFunction.swift
@@ -1,9 +1,3 @@
-//
-//  CloseFunction.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/08/24.
-//
 
 import UserNotifications
 

--- a/Extension/Enums/Collection.swift
+++ b/Extension/Enums/Collection.swift
@@ -1,9 +1,3 @@
-//
-//  Collection.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 import Photos
 

--- a/Extension/Enums/CollectionButtonMode.swift
+++ b/Extension/Enums/CollectionButtonMode.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionButtonMode.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 enum CollectionButtonMode {
     case thumbnail

--- a/Extension/Extensions/Color.swift
+++ b/Extension/Extensions/Color.swift
@@ -1,9 +1,3 @@
-//
-//  String.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/27.
-//
 
 import SwiftUI
 

--- a/Extension/Extensions/SelectedCollections.swift
+++ b/Extension/Extensions/SelectedCollections.swift
@@ -1,0 +1,24 @@
+//
+//  SelectedCollections.swift
+//  Bromides
+//
+//  Created by シン・ジャスティン on 2026/06/11.
+//
+
+import Photos
+
+extension [PHAssetCollection] {
+    func isSelected(_ collection: PHCollection) -> Bool {
+        contains(where: { $0.localIdentifier == collection.localIdentifier })
+    }
+
+    mutating func toggle(_ collection: PHAssetCollection, allowingMultiple: Bool) {
+        if let index = firstIndex(where: { $0.localIdentifier == collection.localIdentifier }) {
+            remove(at: index)
+        } else if allowingMultiple {
+            append(collection)
+        } else {
+            self = [collection]
+        }
+    }
+}

--- a/Extension/Extensions/SelectedCollections.swift
+++ b/Extension/Extensions/SelectedCollections.swift
@@ -1,9 +1,3 @@
-//
-//  SelectedCollections.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2026/06/11.
-//
 
 import Photos
 

--- a/Extension/View Controllers/ShareViewController.swift
+++ b/Extension/View Controllers/ShareViewController.swift
@@ -1,9 +1,3 @@
-//
-//  ShareViewController.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/22.
-//
 
 import SwiftData
 @preconcurrency import SwiftUI

--- a/Extension/View Modifiers/MacToolbar.swift
+++ b/Extension/View Modifiers/MacToolbar.swift
@@ -23,22 +23,12 @@ struct MacToolbar: ViewModifier {
     @FocusState.Binding var isSearchFieldFocused: Bool
 
     var hasSearchBar: Bool
-    var saveAction: (() -> Void)?
-    var isSaveDisabled: Bool
 
     func body(content: Content) -> some View {
         content
             #if os(macOS)
             .safeAreaInset(edge: .top, spacing: 0.0) {
                 HStack(alignment: .center) {
-                    Button(role: .cancel, action: close) {
-                        Text("Shared.Cancel")
-                            .frame(height: 32.0)
-                            .padding(.horizontal, 8.0)
-                            .contentShape(.rect)
-                    }
-                    .buttonStyle(.plain)
-                    .glassEffect(.regular.interactive(), in: .capsule)
                     if !navigator.viewPath.isEmpty {
                         Button {
                             _ = navigator.viewPath.popLast()
@@ -85,19 +75,17 @@ struct MacToolbar: ViewModifier {
                             }
                             .glassEffect(.regular.interactive(), in: .capsule)
                     }
-                    if let saveAction {
-                        Button(role: .confirm, action: saveAction) {
-                            Text("Shared.Save")
-                                .frame(height: 32.0)
-                                .padding(.horizontal, 8.0)
-                                .contentShape(.rect)
-                        }
-                        .buttonStyle(.plain)
-                        .frame(height: 32.0)
-                        .glassEffect(.regular.interactive().tint(.accent), in: .capsule)
-                        .accessibilityLabel(Text("Shared.Save"))
-                        .disabled(isSaveDisabled)
+                    Button(role: .cancel, action: close) {
+                        Image(systemName: "xmark")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 14.0, height: 14.0)
+                            .padding(10.0)
+                            .contentShape(.rect)
                     }
+                    .buttonStyle(.plain)
+                    .glassEffect(.regular.interactive(), in: .circle)
+                    .accessibilityLabel(Text("Shared.Cancel"))
                 }
                 .frame(maxWidth: .infinity, minHeight: 32.0, maxHeight: 32.0)
                 .padding(8.0)
@@ -117,16 +105,12 @@ extension View {
     func toolbarForMac(
         navigator: Binding<Navigator>,
         isSearchFieldFocused: FocusState<Bool>.Binding,
-        hasSearchBar: Bool = true,
-        saveAction: (() -> Void)? = nil,
-        isSaveDisabled: Bool = false
+        hasSearchBar: Bool = true
     ) -> some View {
         self.modifier(MacToolbar(
             navigator: navigator,
             isSearchFieldFocused: isSearchFieldFocused,
-            hasSearchBar: hasSearchBar,
-            saveAction: saveAction,
-            isSaveDisabled: isSaveDisabled
+            hasSearchBar: hasSearchBar
         ))
     }
 }

--- a/Extension/View Modifiers/MacToolbar.swift
+++ b/Extension/View Modifiers/MacToolbar.swift
@@ -1,9 +1,3 @@
-//
-//  MacToolbar.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/08/24.
-//
 
 import SwiftUI
 

--- a/Extension/View Modifiers/MacToolbar.swift
+++ b/Extension/View Modifiers/MacToolbar.swift
@@ -23,6 +23,8 @@ struct MacToolbar: ViewModifier {
     @FocusState.Binding var isSearchFieldFocused: Bool
 
     var hasSearchBar: Bool
+    var saveAction: (() -> Void)?
+    var isSaveDisabled: Bool
 
     func body(content: Content) -> some View {
         content
@@ -83,6 +85,19 @@ struct MacToolbar: ViewModifier {
                             }
                             .glassEffect(.regular.interactive(), in: .capsule)
                     }
+                    if let saveAction {
+                        Button(role: .confirm, action: saveAction) {
+                            Text("Shared.Save")
+                                .frame(height: 32.0)
+                                .padding(.horizontal, 8.0)
+                                .contentShape(.rect)
+                        }
+                        .buttonStyle(.plain)
+                        .frame(height: 32.0)
+                        .glassEffect(.regular.interactive().tint(.accent), in: .capsule)
+                        .accessibilityLabel(Text("Shared.Save"))
+                        .disabled(isSaveDisabled)
+                    }
                 }
                 .frame(maxWidth: .infinity, minHeight: 32.0, maxHeight: 32.0)
                 .padding(8.0)
@@ -102,12 +117,16 @@ extension View {
     func toolbarForMac(
         navigator: Binding<Navigator>,
         isSearchFieldFocused: FocusState<Bool>.Binding,
-        hasSearchBar: Bool = true
+        hasSearchBar: Bool = true,
+        saveAction: (() -> Void)? = nil,
+        isSaveDisabled: Bool = false
     ) -> some View {
         self.modifier(MacToolbar(
             navigator: navigator,
             isSearchFieldFocused: isSearchFieldFocused,
-            hasSearchBar: hasSearchBar
+            hasSearchBar: hasSearchBar,
+            saveAction: saveAction,
+            isSaveDisabled: isSaveDisabled
         ))
     }
 }

--- a/Extension/Views/Collections/CollectionCheckmark.swift
+++ b/Extension/Views/Collections/CollectionCheckmark.swift
@@ -26,6 +26,7 @@ struct CollectionCheckmark: View {
                     Circle()
                         .stroke(.white, lineWidth: lineWidth)
                 }
+                .shadow(color: .black.opacity(0.3), radius: 2.0, y: 1.0)
         }
     }
 }

--- a/Extension/Views/Collections/CollectionCheckmark.swift
+++ b/Extension/Views/Collections/CollectionCheckmark.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionCheckmark.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/04/05.
-//
 
 import SwiftUI
 

--- a/Extension/Views/Collections/CollectionCover.swift
+++ b/Extension/Views/Collections/CollectionCover.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionCover.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/04/05.
-//
 
 import Photos
 import SwiftUI

--- a/Extension/Views/Collections/CollectionGrid.swift
+++ b/Extension/Views/Collections/CollectionGrid.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionGrid.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/04/05.
-//
 
 import Photos
 import SwiftUI

--- a/Extension/Views/Collections/CollectionGrid.swift
+++ b/Extension/Views/Collections/CollectionGrid.swift
@@ -10,14 +10,16 @@ import SwiftUI
 
 struct CollectionGrid: View {
     var collections: [Collection]?
-    @Binding var selectedCollection: PHAssetCollection?
+    @Binding var selectedCollections: [PHAssetCollection]
+
+    @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
 
     init(
         _ collections: [Collection]?,
-        selection selectedCollection: Binding<PHAssetCollection?>
+        selection selectedCollections: Binding<[PHAssetCollection]>
     ) {
         self.collections = collections
-        self._selectedCollection = selectedCollection
+        self._selectedCollections = selectedCollections
     }
 
     var body: some View {
@@ -30,14 +32,16 @@ struct CollectionGrid: View {
                     switch collection {
                     case .album(let album):
                         Button {
-                            withAnimation(.smooth.speed(2.0)) {
-                                selectedCollection = album as? PHAssetCollection
+                            if let album = album as? PHAssetCollection {
+                                withAnimation(.smooth.speed(2.0)) {
+                                    selectedCollections.toggle(album, allowingMultiple: multipleAlbumSelection)
+                                }
                             }
                         } label: {
                             CollectionButtonLabel(
                                 collection: collection,
                                 mode: .grid,
-                                isSelected: { selectedCollection == album }
+                                isSelected: { selectedCollections.isSelected(album) }
                             )
                         }
                         .buttonStyle(.plain)

--- a/Extension/Views/Collections/CollectionGridButtonLabel.swift
+++ b/Extension/Views/Collections/CollectionGridButtonLabel.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionButtonLabel.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 import Photos
 import SwiftUI

--- a/Extension/Views/Collections/CollectionList.swift
+++ b/Extension/Views/Collections/CollectionList.swift
@@ -10,14 +10,16 @@ import SwiftUI
 
 struct CollectionList: View {
     var collections: [Collection]?
-    @Binding var selectedCollection: PHAssetCollection?
+    @Binding var selectedCollections: [PHAssetCollection]
+
+    @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
 
     init(
         _ collections: [Collection]?,
-        selection selectedCollection: Binding<PHAssetCollection?>
+        selection selectedCollections: Binding<[PHAssetCollection]>
     ) {
         self.collections = collections
-        self._selectedCollection = selectedCollection
+        self._selectedCollections = selectedCollections
     }
 
     var body: some View {
@@ -26,14 +28,16 @@ struct CollectionList: View {
                 switch collection {
                 case .album(let album):
                     Button {
-                        withAnimation(.smooth.speed(2.0)) {
-                            selectedCollection = album as? PHAssetCollection
+                        if let album = album as? PHAssetCollection {
+                            withAnimation(.smooth.speed(2.0)) {
+                                selectedCollections.toggle(album, allowingMultiple: multipleAlbumSelection)
+                            }
                         }
                     } label: {
                         CollectionButtonLabel(
                             collection: collection,
                             mode: .list,
-                            isSelected: { selectedCollection == album }
+                            isSelected: { selectedCollections.isSelected(album) }
                         )
                         #if os(macOS)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Extension/Views/Collections/CollectionList.swift
+++ b/Extension/Views/Collections/CollectionList.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionList.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/04/05.
-//
 
 import Photos
 import SwiftUI

--- a/Extension/Views/Collections/CollectionPanels.swift
+++ b/Extension/Views/Collections/CollectionPanels.swift
@@ -10,14 +10,16 @@ import SwiftUI
 
 struct CollectionPanels: View {
     var collections: [Collection]?
-    @Binding var selectedCollection: PHAssetCollection?
+    @Binding var selectedCollections: [PHAssetCollection]
+
+    @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
 
     init(
         _ collections: [Collection]?,
-        selection selectedCollection: Binding<PHAssetCollection?>
+        selection selectedCollections: Binding<[PHAssetCollection]>
     ) {
         self.collections = collections
-        self._selectedCollection = selectedCollection
+        self._selectedCollections = selectedCollections
     }
 
     var body: some View {
@@ -30,14 +32,16 @@ struct CollectionPanels: View {
                     switch collection {
                     case .album(let album):
                         Button {
-                            withAnimation(.smooth.speed(2.0)) {
-                                selectedCollection = album as? PHAssetCollection
+                            if let album = album as? PHAssetCollection {
+                                withAnimation(.smooth.speed(2.0)) {
+                                    selectedCollections.toggle(album, allowingMultiple: multipleAlbumSelection)
+                                }
                             }
                         } label: {
                             CollectionButtonLabel(
                                 collection: collection,
                                 mode: .panels,
-                                isSelected: { selectedCollection == album }
+                                isSelected: { selectedCollections.isSelected(album) }
                             )
                         }
                         .buttonStyle(.plain)

--- a/Extension/Views/Collections/CollectionPanels.swift
+++ b/Extension/Views/Collections/CollectionPanels.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionPanels.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/04/05.
-//
 
 import Photos
 import SwiftUI

--- a/Extension/Views/Collections/CollectionView.swift
+++ b/Extension/Views/Collections/CollectionView.swift
@@ -16,6 +16,8 @@ struct CollectionView: View {
 
     @AppStorage(wrappedValue: .grid, "DisplayMode", store: defaults) var displayMode: DisplayMode
     @AppStorage(wrappedValue: false, "AutoSelectSearch", store: defaults) var autoSelectFirstSearchResult: Bool
+    @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
+    @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
 
     @State var displayedCollection: Collection?
     @State var collections: [Collection]?
@@ -25,28 +27,29 @@ struct CollectionView: View {
     @State var isCreatingAlbum: Bool = false
     @State var isCreatingFolder: Bool = false
     @State var newCollectionName: String = ""
+    @State var isSelectionPopoverPresented: Bool = false
 
     var saveAction: () -> Void
 
-    @Binding var selectedCollection: PHAssetCollection?
+    @Binding var selectedCollections: [PHAssetCollection]
 
     init(
         _ collection: Collection? = nil,
-        selection: Binding<PHAssetCollection?>,
+        selection: Binding<[PHAssetCollection]>,
         saveAction: @escaping () -> Void
     ) {
         self.displayedCollection = collection
-        self._selectedCollection = selection
+        self._selectedCollections = selection
         self.saveAction = saveAction
     }
 
     init(
         searchTerm: String,
-        selection: Binding<PHAssetCollection?>,
+        selection: Binding<[PHAssetCollection]>,
         saveAction: @escaping () -> Void
     ) {
         self.displayedCollection = .search
-        self._selectedCollection = selection
+        self._selectedCollections = selection
         self.searchTerm = searchTerm
         self.saveAction = saveAction
     }
@@ -55,11 +58,11 @@ struct CollectionView: View {
         Group {
             switch displayMode {
             case .grid:
-                CollectionGrid(collections, selection: $selectedCollection)
+                CollectionGrid(collections, selection: $selectedCollections)
             case .list:
-                CollectionList(collections, selection: $selectedCollection)
+                CollectionList(collections, selection: $selectedCollections)
             case .panels:
-                CollectionPanels(collections, selection: $selectedCollection)
+                CollectionPanels(collections, selection: $selectedCollections)
             }
         }
         .overlay {
@@ -80,7 +83,10 @@ struct CollectionView: View {
                 default: EmptyView()
                 }
                 Spacer()
-                saveButton()
+                if multipleAlbumSelection {
+                    selectionSummaryButton()
+                    Spacer()
+                }
             }
             .frame(maxWidth: .infinity, minHeight: 32.0, maxHeight: 32.0)
             .padding(8.0)
@@ -96,6 +102,12 @@ struct CollectionView: View {
         // Use native toolbar on iOS
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                cancelButton()
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                saveButton()
+            }
             ToolbarItem(placement: .bottomBar) {
                 switch displayedCollection {
                 case .folder, nil: newMenu()
@@ -103,11 +115,11 @@ struct CollectionView: View {
                 }
             }
             ToolbarSpacer(.flexible, placement: .bottomBar)
-            ToolbarItem(placement: .bottomBar) {
-                saveButton()
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                closeButton()
+            if multipleAlbumSelection {
+                ToolbarItem(placement: .bottomBar) {
+                    selectionSummaryButton()
+                }
+                ToolbarSpacer(.flexible, placement: .bottomBar)
             }
         }
         #endif
@@ -153,7 +165,10 @@ struct CollectionView: View {
                 if autoSelectFirstSearchResult, let collections, collections.count == 1 {
                     switch collections.first {
                     case .album(let album):
-                        selectedCollection = album as? PHAssetCollection
+                        if let album = album as? PHAssetCollection,
+                           !selectedCollections.isSelected(album) {
+                            selectedCollections.toggle(album, allowingMultiple: multipleAlbumSelection)
+                        }
                     default: break
                     }
                 }
@@ -164,10 +179,13 @@ struct CollectionView: View {
     }
 
     func checkAndResetSelection() {
-        if !(collections ?? []).contains(where: {
-            $0.id == selectedCollection?.localIdentifier
-        }) {
-            selectedCollection = nil
+        // Keep selections made in other albums and folders when selecting multiple albums
+        if !multipleAlbumSelection {
+            selectedCollections.removeAll { selectedCollection in
+                !(collections ?? []).contains(where: {
+                    $0.id == selectedCollection.localIdentifier
+                })
+            }
         }
     }
 
@@ -234,31 +252,38 @@ struct CollectionView: View {
 
     @ViewBuilder
     func saveButton() -> some View {
-        Group {
-            #if os(macOS)
-            Button(role: .confirm, action: saveAction) {
-                Label("Shared.Save", systemImage: "square.and.arrow.down")
-                    .frame(height: 32.0)
-                    .padding(.horizontal, 8.0)
-                    .contentShape(.rect)
-            }
-            .buttonStyle(.plain)
-            .frame(height: 32.0)
-            .glassEffect(.regular.interactive().tint(.accent), in: .capsule)
-            #else
-            Button(
-                "Shared.Save",
-                systemImage: "square.and.arrow.down",
-                role: .confirm,
-                action: saveAction
-            )
-            #endif
-        }
-        .disabled(selectedCollection == nil)
+        Button(role: .confirm, action: saveAction)
+            .accessibilityLabel(Text("Shared.Save"))
+            .disabled(selectedCollections.isEmpty && !noAlbumSelection)
     }
 
     @ViewBuilder
-    func closeButton() -> some View {
+    func cancelButton() -> some View {
         Button(role: .cancel, action: close)
+            .accessibilityLabel(Text("Shared.Cancel"))
+    }
+
+    @ViewBuilder
+    func selectionSummaryButton() -> some View {
+        Button {
+            isSelectionPopoverPresented = true
+        } label: {
+            Text("Shared.AlbumsSelected.\(selectedCollections.count)")
+            #if os(macOS)
+                .frame(height: 32.0)
+                .padding(.horizontal, 8.0)
+                .contentShape(.rect)
+            #endif
+        }
+        #if os(macOS)
+        .buttonStyle(.plain)
+        .frame(height: 32.0)
+        .glassEffect(.regular.interactive(), in: .capsule)
+        #endif
+        .disabled(selectedCollections.isEmpty)
+        .popover(isPresented: $isSelectionPopoverPresented) {
+            SelectedAlbumsView(selection: $selectedCollections)
+                .presentationCompactAdaptation(.popover)
+        }
     }
 }

--- a/Extension/Views/Collections/CollectionView.swift
+++ b/Extension/Views/Collections/CollectionView.swift
@@ -33,6 +33,13 @@ struct CollectionView: View {
 
     @Binding var selectedCollections: [PHAssetCollection]
 
+    var hasNewMenu: Bool {
+        switch displayedCollection {
+        case .folder, nil: return true
+        default: return false
+        }
+    }
+
     init(
         _ collection: Collection? = nil,
         selection: Binding<[PHAssetCollection]>,
@@ -77,18 +84,22 @@ struct CollectionView: View {
         #if os(macOS)
         // Show custom toolbar on macOS
         .safeAreaInset(edge: .bottom, spacing: 0.0) {
-            HStack(alignment: .center) {
-                switch displayedCollection {
-                case .folder, nil: newMenu()
-                default: EmptyView()
+            VStack(alignment: .center, spacing: 8.0) {
+                if hasNewMenu || multipleAlbumSelection {
+                    HStack(alignment: .center) {
+                        if hasNewMenu {
+                            newMenu()
+                        }
+                        Spacer()
+                        if multipleAlbumSelection {
+                            selectionSummaryButton()
+                            Spacer()
+                        }
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 32.0, maxHeight: 32.0)
                 }
-                Spacer()
-                if multipleAlbumSelection {
-                    selectionSummaryButton()
-                    Spacer()
-                }
+                saveButton()
             }
-            .frame(maxWidth: .infinity, minHeight: 32.0, maxHeight: 32.0)
             .padding(8.0)
             .background(Material.ultraThin)
             .overlay(alignment: .top) {
@@ -108,10 +119,9 @@ struct CollectionView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 saveButton()
             }
-            ToolbarItem(placement: .bottomBar) {
-                switch displayedCollection {
-                case .folder, nil: newMenu()
-                default: EmptyView()
+            if hasNewMenu {
+                ToolbarItem(placement: .bottomBar) {
+                    newMenu()
                 }
             }
             ToolbarSpacer(.flexible, placement: .bottomBar)
@@ -252,9 +262,22 @@ struct CollectionView: View {
 
     @ViewBuilder
     func saveButton() -> some View {
-        Button(role: .confirm, action: saveAction)
-            .accessibilityLabel(Text("Shared.Save"))
-            .disabled(selectedCollections.isEmpty && !noAlbumSelection)
+        Group {
+            #if os(macOS)
+            Button(role: .confirm, action: saveAction) {
+                Label("Shared.Save", systemImage: "square.and.arrow.down")
+                    .bold()
+                    .frame(maxWidth: .infinity, minHeight: 32.0, maxHeight: 32.0)
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .glassEffect(.regular.interactive().tint(.accent), in: .capsule)
+            #else
+            Button(role: .confirm, action: saveAction)
+            #endif
+        }
+        .accessibilityLabel(Text("Shared.Save"))
+        .disabled(selectedCollections.isEmpty && !noAlbumSelection)
     }
 
     @ViewBuilder

--- a/Extension/Views/Collections/CollectionView.swift
+++ b/Extension/Views/Collections/CollectionView.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionView.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 import Komponents
 import Photos

--- a/Extension/Views/Collections/CollectionsStack.swift
+++ b/Extension/Views/Collections/CollectionsStack.swift
@@ -1,9 +1,3 @@
-//
-//  CollectionsStack.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/04/06.
-//
 
 import Photos
 import SwiftUI

--- a/Extension/Views/Collections/CollectionsStack.swift
+++ b/Extension/Views/Collections/CollectionsStack.swift
@@ -13,7 +13,6 @@ struct CollectionsStack: View {
     @Binding var selectedCollections: [PHAssetCollection]
 
     @AppStorage(wrappedValue: false, "AutoOpenKeyboard", store: defaults) var autoOpenKeyboard: Bool
-    @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
     @FocusState var isSearchFieldFocused: Bool
 
     #if !os(macOS)
@@ -52,9 +51,7 @@ struct CollectionsStack: View {
                 // (NavigationStack title/back button/toolbars aren't available in share sheet)
                 .toolbarForMac(
                     navigator: self.$navigator,
-                    isSearchFieldFocused: $isSearchFieldFocused,
-                    saveAction: saveAction,
-                    isSaveDisabled: selectedCollections.isEmpty && !noAlbumSelection
+                    isSearchFieldFocused: $isSearchFieldFocused
                 )
                 #else
                 // Use native search features on iOS
@@ -98,9 +95,7 @@ struct CollectionsStack: View {
                         .toolbarForMac(
                             navigator: self.$navigator,
                             isSearchFieldFocused: $isSearchFieldFocused,
-                            hasSearchBar: false,
-                            saveAction: saveAction,
-                            isSaveDisabled: selectedCollections.isEmpty && !noAlbumSelection
+                            hasSearchBar: false
                         )
                 }
         }

--- a/Extension/Views/Collections/CollectionsStack.swift
+++ b/Extension/Views/Collections/CollectionsStack.swift
@@ -10,9 +10,10 @@ import SwiftUI
 
 struct CollectionsStack: View {
     @Binding var navigator: Navigator
-    @Binding var selectedCollection: PHAssetCollection?
+    @Binding var selectedCollections: [PHAssetCollection]
 
     @AppStorage(wrappedValue: false, "AutoOpenKeyboard", store: defaults) var autoOpenKeyboard: Bool
+    @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
     @FocusState var isSearchFieldFocused: Bool
 
     #if !os(macOS)
@@ -30,11 +31,11 @@ struct CollectionsStack: View {
 
     init(
         _ navigator: Binding<Navigator>,
-        selection selectedCollection: Binding<PHAssetCollection?>,
+        selection selectedCollections: Binding<[PHAssetCollection]>,
         saveAction: @escaping () -> Void
     ) {
         self._navigator = navigator
-        self._selectedCollection = selectedCollection
+        self._selectedCollections = selectedCollections
         self.saveAction = saveAction
         #if !os(macOS)
         UITextField.appearance().clearButtonMode = .whileEditing
@@ -44,14 +45,16 @@ struct CollectionsStack: View {
     var body: some View {
         NavigationStack(path: $navigator.viewPath) {
             @Bindable var navigator = navigator
-            CollectionView(selection: $selectedCollection, saveAction: saveAction)
+            CollectionView(selection: $selectedCollections, saveAction: saveAction)
                 .environment(navigator)
                 #if os(macOS)
                 // Show custom toolbar and search bar on macOS
                 // (NavigationStack title/back button/toolbars aren't available in share sheet)
                 .toolbarForMac(
                     navigator: self.$navigator,
-                    isSearchFieldFocused: $isSearchFieldFocused
+                    isSearchFieldFocused: $isSearchFieldFocused,
+                    saveAction: saveAction,
+                    isSaveDisabled: selectedCollections.isEmpty && !noAlbumSelection
                 )
                 #else
                 // Use native search features on iOS
@@ -90,12 +93,14 @@ struct CollectionsStack: View {
                 .scrollDismissesKeyboard(.never)
                 #endif
                 .navigationDestination(for: Collection.self) { collection in
-                    CollectionView(collection, selection: $selectedCollection, saveAction: saveAction)
+                    CollectionView(collection, selection: $selectedCollections, saveAction: saveAction)
                         .environment(navigator)
                         .toolbarForMac(
                             navigator: self.$navigator,
                             isSearchFieldFocused: $isSearchFieldFocused,
-                            hasSearchBar: false
+                            hasSearchBar: false,
+                            saveAction: saveAction,
+                            isSaveDisabled: selectedCollections.isEmpty && !noAlbumSelection
                         )
                 }
         }

--- a/Extension/Views/Collections/SelectedAlbumsView.swift
+++ b/Extension/Views/Collections/SelectedAlbumsView.swift
@@ -1,0 +1,55 @@
+//
+//  SelectedAlbumsView.swift
+//  Bromides
+//
+//  Created by シン・ジャスティン on 2026/06/11.
+//
+
+import Photos
+import SwiftUI
+
+struct SelectedAlbumsView: View {
+    @Environment(\.dismiss) var dismiss
+
+    @Binding var selectedCollections: [PHAssetCollection]
+
+    init(selection selectedCollections: Binding<[PHAssetCollection]>) {
+        self._selectedCollections = selectedCollections
+    }
+
+    var body: some View {
+        List(selectedCollections, id: \.localIdentifier) { collection in
+            HStack(alignment: .center, spacing: 16.0) {
+                CollectionButtonLabel(
+                    collection: .album(collection: collection),
+                    mode: .list
+                )
+                Spacer(minLength: 0.0)
+                Button {
+                    withAnimation(.smooth.speed(2.0)) {
+                        selectedCollections.removeAll(where: {
+                            $0.localIdentifier == collection.localIdentifier
+                        })
+                    }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Text("Shared.Remove"))
+            }
+            .listRowInsets(.init(top: 6.0, leading: 20.0, bottom: 6.0, trailing: 20.0))
+        }
+        .listStyle(.plain)
+        .frame(
+            minWidth: 280.0,
+            minHeight: min(CGFloat(max(selectedCollections.count, 1)) * 50.0 + 12.0, 312.0)
+        )
+        .onChange(of: selectedCollections) { _, newValue in
+            if newValue.isEmpty {
+                dismiss()
+            }
+        }
+    }
+}

--- a/Extension/Views/Collections/SelectedAlbumsView.swift
+++ b/Extension/Views/Collections/SelectedAlbumsView.swift
@@ -1,9 +1,3 @@
-//
-//  SelectedAlbumsView.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2026/06/11.
-//
 
 import Photos
 import SwiftUI

--- a/Extension/Views/ShareView.swift
+++ b/Extension/Views/ShareView.swift
@@ -1,9 +1,3 @@
-//
-//  ShareView.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/22.
-//
 
 import Komponents
 import Photos

--- a/Extension/Views/ShareView.swift
+++ b/Extension/Views/ShareView.swift
@@ -17,12 +17,14 @@ struct ShareView: View {
     @AppStorage(wrappedValue: true, "SaveRecentAlbums", store: defaults) var saveRecentAlbums: Bool
     @AppStorage(wrappedValue: true, "ShowSaveAnimation", store: defaults) var showSaveAnimation: Bool
     @AppStorage(wrappedValue: Data(), "RecentAlbums", store: defaults) var recentAlbumsData: Data
+    @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
 
     @State var navigator: Navigator = Navigator()
     var imageData: Data?
     var previewImage: XPImage?
 
-    @State var selectedCollection: PHAssetCollection?
+    @State var selectedCollections: [PHAssetCollection] = []
+    @State var savingAlbumName: String?
     @State var isPhotoSaving: Bool = false
     @State var isPhotoSaveSuccessful: Bool = false
     @State var isPhotoSaveFailed: Bool = false
@@ -107,30 +109,48 @@ struct ShareView: View {
         }
     }
 
+    @ViewBuilder
+    func savingProgressView() -> some View {
+        VStack(alignment: .center, spacing: 16.0) {
+            ProgressView()
+                .progressViewStyle(.circular)
+            Group {
+                if let savingAlbumName {
+                    Text("Message.Saving.\(savingAlbumName)")
+                } else {
+                    Text("Shared.Saving")
+                }
+            }
+            .bold()
+        }
+    }
+
     func save() {
-        if !isPhotoSaving, let imageData, let selectedCollection {
-            isPhotoSaving = true
+        if !isPhotoSaving, let imageData, !selectedCollections.isEmpty || noAlbumSelection {
+            withAnimation(.smooth.speed(2.0)) {
+                isPhotoSaving = true
+            }
+            let collectionsToSaveTo = selectedCollections
             Task {
-                let isPhotoSaved: Bool = await PhotosLibrary.saveImage(
-                    data: imageData,
-                    to: selectedCollection
-                )
+                var isPhotoSaved: Bool = true
+                if collectionsToSaveTo.isEmpty {
+                    isPhotoSaved = await PhotosLibrary.saveImage(data: imageData)
+                } else {
+                    for collection in collectionsToSaveTo {
+                        withAnimation(.smooth.speed(2.0)) {
+                            savingAlbumName = collection.localizedTitle ??
+                                NSLocalizedString("Shared.Album", comment: "")
+                        }
+                        isPhotoSaved = await PhotosLibrary.saveImage(data: imageData, to: collection)
+                        if !isPhotoSaved {
+                            break
+                        }
+                    }
+                }
+                savingAlbumName = nil
                 if isPhotoSaved {
                     if saveRecentAlbums {
-                        if let albumName = selectedCollection.localizedTitle {
-                            var existingRecentAlbums: [String] = (try? JSONDecoder().decode(
-                                [String].self,
-                                from: recentAlbumsData
-                            )) ?? []
-                            if existingRecentAlbums.contains(where: { $0 == albumName}) {
-                                existingRecentAlbums.removeAll(where: { $0 == albumName})
-                            }
-                            existingRecentAlbums.append(albumName)
-                            if existingRecentAlbums.count > 10 {
-                                existingRecentAlbums = Array(existingRecentAlbums.suffix(10))
-                            }
-                            recentAlbumsData = (try? JSONEncoder().encode(existingRecentAlbums)) ?? Data()
-                        }
+                        updateRecentAlbums(with: collectionsToSaveTo.compactMap(\.localizedTitle))
                     }
                     if showSaveAnimation {
                         withAnimation(.smooth.speed(2.0)) {
@@ -145,13 +165,31 @@ struct ShareView: View {
                     #if os(iOS)
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
                     #endif
-                    isPhotoSaving = false
+                    withAnimation(.smooth.speed(2.0)) {
+                        isPhotoSaving = false
+                    }
                     isPhotoSaveFailed = true
                 }
             }
         } else {
             isPhotoSaveFailed = true
         }
+    }
+
+    func updateRecentAlbums(with albumNames: [String]) {
+        guard !albumNames.isEmpty else { return }
+        var existingRecentAlbums: [String] = (try? JSONDecoder().decode(
+            [String].self,
+            from: recentAlbumsData
+        )) ?? []
+        for albumName in albumNames {
+            existingRecentAlbums.removeAll(where: { $0 == albumName })
+            existingRecentAlbums.append(albumName)
+        }
+        if existingRecentAlbums.count > 10 {
+            existingRecentAlbums = Array(existingRecentAlbums.suffix(10))
+        }
+        recentAlbumsData = (try? JSONEncoder().encode(existingRecentAlbums)) ?? Data()
     }
 
     func closeWithHaptics(shouldWait: Bool = true) {

--- a/Extension/Views/Shared/ButtonLabel.swift
+++ b/Extension/Views/Shared/ButtonLabel.swift
@@ -1,9 +1,3 @@
-//
-//  ButtonLabel.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 import SwiftUI
 

--- a/Extension/Views/Shared/GenericThumbnail.swift
+++ b/Extension/Views/Shared/GenericThumbnail.swift
@@ -1,9 +1,3 @@
-//
-//  GenericThumbnail.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/27.
-//
 
 import SwiftUI
 

--- a/Extension/Views/Shared/ImagePreview.swift
+++ b/Extension/Views/Shared/ImagePreview.swift
@@ -1,9 +1,3 @@
-//
-//  ImagePreview.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 import SwiftUI
 #if os(macOS)

--- a/Extension/Views/Shared/SaveSuccessfulView.swift
+++ b/Extension/Views/Shared/SaveSuccessfulView.swift
@@ -9,10 +9,10 @@ import Photos
 import SwiftUI
 
 struct SaveSuccessfulView: View {
-    var selectedCollection: PHAssetCollection?
+    var selectedCollections: [PHAssetCollection]
 
-    init(_ selectedCollection: PHAssetCollection? = nil) {
-        self.selectedCollection = selectedCollection
+    init(_ selectedCollections: [PHAssetCollection] = []) {
+        self.selectedCollections = selectedCollections
     }
 
     var body: some View {
@@ -21,10 +21,19 @@ struct SaveSuccessfulView: View {
                 .resizable()
                 .frame(width: 48.0, height: 48.0)
                 .symbolRenderingMode(.multicolor)
-            Text("""
-Message.Save.\(selectedCollection?.localizedTitle ?? NSLocalizedString("Shared.Album", comment: ""))
+            Group {
+                switch selectedCollections.count {
+                case 0:
+                    Text("Message.Save.Library")
+                case 1:
+                    Text("""
+Message.Save.\(selectedCollections[0].localizedTitle ?? NSLocalizedString("Shared.Album", comment: ""))
 """)
-                .bold()
+                default:
+                    Text("Message.Save.Multiple.\(selectedCollections.count)")
+                }
+            }
+            .bold()
         }
     }
 }

--- a/Extension/Views/Shared/SaveSuccessfulView.swift
+++ b/Extension/Views/Shared/SaveSuccessfulView.swift
@@ -1,9 +1,3 @@
-//
-//  SaveSuccessfulView.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/04/05.
-//
 
 import Photos
 import SwiftUI

--- a/Extension/Views/Size Classes/Landscape.swift
+++ b/Extension/Views/Size Classes/Landscape.swift
@@ -17,7 +17,7 @@ extension ShareView {
                     .frame(maxWidth: .infinity, minHeight: 160.0, maxHeight: .infinity)
                     .matchedGeometryEffect(id: "@$_bromidesPrivateIdentifier_preview", in: namespace)
                 if isPhotoSaveSuccessful {
-                    SaveSuccessfulView(selectedCollection)
+                    SaveSuccessfulView(selectedCollections)
                         .frame(maxWidth: .infinity)
                         .padding()
                     Spacer()
@@ -27,11 +27,13 @@ extension ShareView {
             }
             if !isPhotoSaveSuccessful {
                 ZStack(alignment: .center) {
-                    if isPhotosAuthorizationComplete {
+                    if isPhotoSaving {
+                        savingProgressView()
+                    } else if isPhotosAuthorizationComplete {
                         if isPhotosAuthorizationDenied {
                             noAccessView()
                         } else {
-                            CollectionsStack($navigator, selection: $selectedCollection, saveAction: save)
+                            CollectionsStack($navigator, selection: $selectedCollections, saveAction: save)
                                 .matchedGeometryEffect(
                                     id: "@$_bromidesPrivateIdentifier_albumBrowser",
                                     in: namespace

--- a/Extension/Views/Size Classes/Landscape.swift
+++ b/Extension/Views/Size Classes/Landscape.swift
@@ -1,9 +1,3 @@
-//
-//  Landscape.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/05/10.
-//
 
 import Komponents
 import SwiftUI

--- a/Extension/Views/Size Classes/Mac.swift
+++ b/Extension/Views/Size Classes/Mac.swift
@@ -1,9 +1,3 @@
-//
-//  Mac.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/05/10.
-//
 
 import Komponents
 import SwiftUI

--- a/Extension/Views/Size Classes/Mac.swift
+++ b/Extension/Views/Size Classes/Mac.swift
@@ -12,16 +12,18 @@ extension ShareView {
     @ViewBuilder func macView(previewImage: XPImage) -> some View {
         VStack(alignment: .leading, spacing: 0.0) {
             if isPhotoSaveSuccessful {
-                SaveSuccessfulView(selectedCollection)
+                SaveSuccessfulView(selectedCollections)
                     .frame(maxWidth: .infinity)
                     .padding()
             } else {
                 ZStack(alignment: .center) {
-                    if isPhotosAuthorizationComplete {
+                    if isPhotoSaving {
+                        savingProgressView()
+                    } else if isPhotosAuthorizationComplete {
                         if isPhotosAuthorizationDenied {
                             noAccessView()
                         } else {
-                            CollectionsStack($navigator, selection: $selectedCollection, saveAction: save)
+                            CollectionsStack($navigator, selection: $selectedCollections, saveAction: save)
                         }
                     } else {
                         ProgressView()

--- a/Extension/Views/Size Classes/Portrait.swift
+++ b/Extension/Views/Size Classes/Portrait.swift
@@ -1,9 +1,3 @@
-//
-//  PortraitShareView.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/05/10.
-//
 
 import Komponents
 import SwiftUI

--- a/Extension/Views/Size Classes/Portrait.swift
+++ b/Extension/Views/Size Classes/Portrait.swift
@@ -15,18 +15,20 @@ extension ShareView {
                 .frame(maxWidth: .infinity, minHeight: 160.0, maxHeight: 160.0)
                 .matchedGeometryEffect(id: "@$_bromidesPrivateIdentifier_preview", in: namespace)
             if isPhotoSaveSuccessful {
-                SaveSuccessfulView(selectedCollection)
+                SaveSuccessfulView(selectedCollections)
                     .frame(maxWidth: .infinity)
                     .padding()
             } else {
                 Divider()
                     .ignoresSafeArea(.all, edges: .horizontal)
                 ZStack(alignment: .center) {
-                    if isPhotosAuthorizationComplete {
+                    if isPhotoSaving {
+                        savingProgressView()
+                    } else if isPhotosAuthorizationComplete {
                         if isPhotosAuthorizationDenied {
                             noAccessView()
                         } else {
-                            CollectionsStack($navigator, selection: $selectedCollection, saveAction: save)
+                            CollectionsStack($navigator, selection: $selectedCollections, saveAction: save)
                                 .matchedGeometryEffect(
                                     id: "@$_bromidesPrivateIdentifier_albumBrowser",
                                     in: namespace

--- a/Shared/CrossPlatformTypes.swift
+++ b/Shared/CrossPlatformTypes.swift
@@ -1,9 +1,3 @@
-//
-//  CrossPlatformTypes.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/08/24.
-//
 
 import SwiftUI
 

--- a/Shared/Defaults.swift
+++ b/Shared/Defaults.swift
@@ -1,9 +1,3 @@
-//
-//  Defaults.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 import Foundation
 

--- a/Shared/Enums/DisplayMode.swift
+++ b/Shared/Enums/DisplayMode.swift
@@ -1,9 +1,3 @@
-//
-//  DisplayMode.swift
-//  Bromides
-//
-//  Created by シン・ジャスティン on 2025/03/23.
-//
 
 enum DisplayMode: String {
     case grid

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -286,6 +286,66 @@
         }
       }
     },
+    "Message.Save.Library" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saved to your photo library"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブラリに保存しました"
+          }
+        }
+      }
+    },
+    "Message.Save.Multiple.%lld" : {
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Saved to %lld album"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Saved to %lld albums"
+                }
+              }
+            }
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld個のアルバムに保存しました"
+          }
+        }
+      }
+    },
+    "Message.Saving.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saving to ‘%@’…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」に保存中…"
+          }
+        }
+      }
+    },
     "Onboarding.1.%@" : {
       "localizations" : {
         "en" : {
@@ -544,6 +604,38 @@
         }
       }
     },
+    "Settings.MultipleAlbumSelection" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Multiple Albums"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複数のアルバムを選択"
+          }
+        }
+      }
+    },
+    "Settings.NoAlbumSelection" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow Saving Without Album"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アルバムなしでの保存を許可"
+          }
+        }
+      }
+    },
     "Settings.SaveRecents" : {
       "localizations" : {
         "en" : {
@@ -606,6 +698,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アルバム名"
+          }
+        }
+      }
+    },
+    "Shared.AlbumsSelected.%lld" : {
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld album selected"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld albums selected"
+                }
+              }
+            }
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld個のアルバムを選択中"
           }
         }
       }
@@ -707,6 +827,22 @@
         }
       }
     },
+    "Shared.Remove" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        }
+      }
+    },
     "Shared.SamplePhoto" : {
       "localizations" : {
         "en" : {
@@ -735,6 +871,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存"
+          }
+        }
+      }
+    },
+    "Shared.Saving" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saving…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存中…"
           }
         }
       }


### PR DESCRIPTION
Resolves #2, resolves #3, resolves #10, and resolves #12.

## Main app
- New **Select Multiple Albums** toggle (default off) enables multiple album selection in the share extension.
- New **Allow Saving Without Album** toggle (default off) enables the Save button even when no album is selected; the photo is then saved directly to the photo library.
- Both toggles are available in the iOS and macOS settings screens.

## Share extension
- Selection is now tracked as an array of albums. Tapping an album toggles its selection; when multiple album selection is off, the previous single-selection behaviour is preserved.
- When multiple album selection is on, a **'X album(s) selected'** item appears centered in the bottom toolbar (spaced with `ToolbarSpacer`s on iOS). Tapping it opens a popover listing the selected albums, each with an X button at the trailing edge to remove it from the selection.
- The selection checkmark overlay (multicolor `checkmark.circle.fill` with a white outline, centered over a dimmed album cover) now also has a slight shadow.
- Saving to multiple albums saves to each album in turn and shows a progress view with **Saving to 'ALBUM_NAME'…** for the album currently being assigned. All saved-to albums are recorded in recent albums.
- The save success message now adapts: saved to library (no album), saved to one album (existing message), or saved to N albums.

## Save/Cancel rework
- On iOS, **Cancel** is now in the top leading bar and **Save** in the top trailing bar, using `Button(role: .cancel)` / `Button(role: .confirm)` without labels; the existing Save/Cancel wording is reused as accessibility labels.
- While the save progress view is shown, the album browser (and with it every Cancel/Save button) is hidden, so neither button can be tapped during a save (#12).

## macOS share sheet layout
The macOS share sheet uses custom glass controls throughout (the share sheet has no usable native SwiftUI toolbar):
- Top bar: back button/title on the leading edge, with the search field and a circular X close button on the trailing edge.
- Bottom area: a toolbar row with the New menu and the album selection summary (with its popover), above a full-width, accent-tinted Save button.

New strings have been added to `Localizable.xcstrings` with English and Japanese translations, including plural variations for the album counts.

https://claude.ai/code/session_018n6kDk5eAQ16QEu2ujDtuV