### PR TITLE
Enhance album search with tokens, folders, and search scope

### DIFF
--- a/App/Views/MacOnboardingView.swift
+++ b/App/Views/MacOnboardingView.swift
@@ -7,6 +7,7 @@ struct MacOnboardingView: View {
     @AppStorage(wrappedValue: true, "SaveRecentAlbums", store: defaults) var saveRecentAlbums: Bool
     @AppStorage(wrappedValue: true, "ShowSaveAnimation", store: defaults) var showSaveAnimation: Bool
     @AppStorage(wrappedValue: false, "AutoSelectSearch", store: defaults) var autoSelectFirstSearchResult: Bool
+    @AppStorage(wrappedValue: .everywhere, "SearchScope", store: defaults) var searchScope: SearchScope
     @AppStorage(wrappedValue: false, "AutoOpenKeyboard", store: defaults) var autoOpenKeyboard: Bool
     @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
     @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
@@ -90,26 +91,41 @@ struct MacOnboardingView: View {
                 }
             }
             Tab("Settings.Title", systemImage: "gear") {
-                VStack(alignment: .leading, spacing: 8.0) {
-                    Picker(selection: $displayMode) {
-                        Text("Settings.DisplayMode.Grid")
-                            .tag(DisplayMode.grid)
-                        Text("Settings.DisplayMode.List")
-                            .tag(DisplayMode.list)
-                        Text("Settings.DisplayMode.Panels")
-                            .tag(DisplayMode.panels)
-                    } label: {
-                        Text("Settings.DisplayMode")
+                Form {
+                    Section("Settings.Appearance") {
+                        Picker(selection: $displayMode) {
+                            Text("Settings.DisplayMode.Grid")
+                                .tag(DisplayMode.grid)
+                            Text("Settings.DisplayMode.List")
+                                .tag(DisplayMode.list)
+                            Text("Settings.DisplayMode.Panels")
+                                .tag(DisplayMode.panels)
+                        } label: {
+                            Text("Settings.DisplayMode")
+                        }
+                        Toggle("Settings.EnableSaveAnimation", isOn: $showSaveAnimation)
                     }
-                    Toggle("Settings.EnableSaveAnimation", isOn: $showSaveAnimation)
-                    Toggle("Settings.SaveRecents", isOn: $saveRecentAlbums)
-                    Toggle("Settings.AutoOpenKeyboard", isOn: $autoOpenKeyboard)
-                    Toggle("Settings.AutoSelectFirstSearchResult", isOn: $autoSelectFirstSearchResult)
-                    Toggle("Settings.MultipleAlbumSelection", isOn: $multipleAlbumSelection)
-                    Toggle("Settings.NoAlbumSelection", isOn: $noAlbumSelection)
+                    Section("Settings.Behaviors") {
+                        Toggle("Settings.SaveRecents", isOn: $saveRecentAlbums)
+                        Toggle("Settings.AutoOpenKeyboard", isOn: $autoOpenKeyboard)
+                    }
+                    Section("Settings.Search") {
+                        Toggle("Settings.AutoSelectFirstSearchResult", isOn: $autoSelectFirstSearchResult)
+                        Picker(selection: $searchScope) {
+                            Text("Settings.SearchIn.CurrentFolder")
+                                .tag(SearchScope.currentFolder)
+                            Text("Settings.SearchIn.Everywhere")
+                                .tag(SearchScope.everywhere)
+                        } label: {
+                            Text("Settings.SearchIn")
+                        }
+                    }
+                    Section("Settings.Selection") {
+                        Toggle("Settings.MultipleAlbumSelection", isOn: $multipleAlbumSelection)
+                        Toggle("Settings.NoAlbumSelection", isOn: $noAlbumSelection)
+                    }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                .padding()
+                .formStyle(.grouped)
             }
             Tab("About.Title", systemImage: "info.circle") {
                 VStack(alignment: .center, spacing: 8.0) {

--- a/App/Views/OnboardingView.swift
+++ b/App/Views/OnboardingView.swift
@@ -7,6 +7,7 @@ struct OnboardingView: View {
     @AppStorage(wrappedValue: true, "SaveRecentAlbums", store: defaults) var saveRecentAlbums: Bool
     @AppStorage(wrappedValue: true, "ShowSaveAnimation", store: defaults) var showSaveAnimation: Bool
     @AppStorage(wrappedValue: false, "AutoSelectSearch", store: defaults) var autoSelectFirstSearchResult: Bool
+    @AppStorage(wrappedValue: .everywhere, "SearchScope", store: defaults) var searchScope: SearchScope
     @AppStorage(wrappedValue: false, "AutoOpenKeyboard", store: defaults) var autoOpenKeyboard: Bool
     @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
     @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
@@ -48,13 +49,33 @@ struct OnboardingView: View {
                         Text("Settings.DisplayMode")
                     }
                     Toggle("Settings.EnableSaveAnimation", isOn: $showSaveAnimation)
+                } header: {
+                    ListSectionHeader(text: "Settings.Appearance")
+                }
+                Section {
                     Toggle("Settings.SaveRecents", isOn: $saveRecentAlbums)
                     Toggle("Settings.AutoOpenKeyboard", isOn: $autoOpenKeyboard)
+                } header: {
+                    ListSectionHeader(text: "Settings.Behaviors")
+                }
+                Section {
                     Toggle("Settings.AutoSelectFirstSearchResult", isOn: $autoSelectFirstSearchResult)
+                    Picker(selection: $searchScope) {
+                        Text("Settings.SearchIn.CurrentFolder")
+                            .tag(SearchScope.currentFolder)
+                        Text("Settings.SearchIn.Everywhere")
+                            .tag(SearchScope.everywhere)
+                    } label: {
+                        Text("Settings.SearchIn")
+                    }
+                } header: {
+                    ListSectionHeader(text: "Settings.Search")
+                }
+                Section {
                     Toggle("Settings.MultipleAlbumSelection", isOn: $multipleAlbumSelection)
                     Toggle("Settings.NoAlbumSelection", isOn: $noAlbumSelection)
                 } header: {
-                    ListSectionHeader(text: "Settings.Title")
+                    ListSectionHeader(text: "Settings.Selection")
                 }
                 Section {
                     Link(destination: URL(string: "https://github.com/katagaki/Bromides")!) {

--- a/Extension/Classes/Navigator.swift
+++ b/Extension/Classes/Navigator.swift
@@ -16,6 +16,7 @@ class Navigator: @unchecked Sendable {
 
     func debounceSearch() {
         if debouncingSearchTerm.trimmingCharacters(in: .whitespaces) == "" {
+            timer?.invalidate()
             searchTerm = ""
         } else if debouncingSearchTerm == searchTerm {
             return

--- a/Extension/Classes/PhotosLibrary.swift
+++ b/Extension/Classes/PhotosLibrary.swift
@@ -52,22 +52,63 @@ class PhotosLibrary {
         return items
     }
 
-    static func albums(containing searchTerm: String) -> [Collection] {
-        var items: [Collection] = []
-        let options: PHFetchOptions = PHFetchOptions()
-        options.sortDescriptors = [
-            NSSortDescriptor(key: "localizedTitle", ascending: true)
-        ]
-        let collections: PHFetchResult = PHAssetCollection.fetchAssetCollections(
-            with: .album, subtype: .any, options: options
-        )
-        collections.enumerateObjects { (collection, _, _) in
-            items.append(.album(collection: collection))
+    static func albumsAndFolders(matching searchTerm: String, in path: Collection? = nil) -> [Collection] {
+        let trimmedSearchTerm = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+        let searchTokens = trimmedSearchTerm
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+        guard !searchTokens.isEmpty else { return [] }
+        var candidates: [Collection] = []
+        if let path, case .folder(let collection) = path, let folder = collection as? PHCollectionList {
+            candidates = albumsAndFoldersRecursively(in: folder)
+        } else {
+            let options: PHFetchOptions = PHFetchOptions()
+            options.sortDescriptors = [
+                NSSortDescriptor(key: "localizedTitle", ascending: true)
+            ]
+            let albums: PHFetchResult = PHAssetCollection.fetchAssetCollections(
+                with: .album, subtype: .any, options: options
+            )
+            albums.enumerateObjects { (collection, _, _) in
+                candidates.append(.album(collection: collection))
+            }
+            let folders: PHFetchResult = PHCollectionList.fetchCollectionLists(
+                with: .folder, subtype: .any, options: options
+            )
+            folders.enumerateObjects { (collection, _, _) in
+                candidates.append(.folder(collection: collection))
+            }
         }
-        items.removeAll(where: { !$0.title.localizedCaseInsensitiveContains(
-            searchTerm.trimmingCharacters(in: .whitespaces)
-        ) })
-        items.sort(by: { $0.title.localizedStandardCompare($1.title) == .orderedAscending })
+        var fullMatches: [Collection] = []
+        var tokenMatches: [Collection] = []
+        for candidate in candidates {
+            let title = candidate.title
+            if title.localizedCaseInsensitiveContains(trimmedSearchTerm) {
+                fullMatches.append(candidate)
+            } else if searchTokens.contains(where: { title.localizedCaseInsensitiveContains($0) }) {
+                tokenMatches.append(candidate)
+            }
+        }
+        fullMatches.sort(by: { $0.title.localizedStandardCompare($1.title) == .orderedAscending })
+        tokenMatches.sort(by: { $0.title.localizedStandardCompare($1.title) == .orderedAscending })
+        return fullMatches + tokenMatches
+    }
+
+    static func albumsAndFoldersRecursively(in folder: PHCollectionList) -> [Collection] {
+        var items: [Collection] = []
+        let collectionItems: PHFetchResult = PHCollection.fetchCollections(in: folder, options: nil)
+        collectionItems.enumerateObjects { (collection, _, _) in
+            if collection.canContainAssets {
+                items.append(.album(collection: collection))
+            } else if collection.canContainCollections {
+                items.append(.folder(collection: collection))
+            }
+        }
+        for item in items {
+            if case .folder(let collection) = item, let childFolder = collection as? PHCollectionList {
+                items.append(contentsOf: albumsAndFoldersRecursively(in: childFolder))
+            }
+        }
         return items
     }
 

--- a/Extension/Views/Collections/CollectionView.swift
+++ b/Extension/Views/Collections/CollectionView.swift
@@ -10,13 +10,13 @@ struct CollectionView: View {
 
     @AppStorage(wrappedValue: .grid, "DisplayMode", store: defaults) var displayMode: DisplayMode
     @AppStorage(wrappedValue: false, "AutoSelectSearch", store: defaults) var autoSelectFirstSearchResult: Bool
+    @AppStorage(wrappedValue: .everywhere, "SearchScope", store: defaults) var searchScope: SearchScope
     @AppStorage(wrappedValue: false, "MultipleAlbumSelection", store: defaults) var multipleAlbumSelection: Bool
     @AppStorage(wrappedValue: false, "NoAlbumSelection", store: defaults) var noAlbumSelection: Bool
 
+    var baseCollection: Collection?
     @State var displayedCollection: Collection?
     @State var collections: [Collection]?
-
-    @State var searchTerm: String?
 
     @State var isCreatingAlbum: Bool = false
     @State var isCreatingFolder: Bool = false
@@ -39,19 +39,9 @@ struct CollectionView: View {
         selection: Binding<[PHAssetCollection]>,
         saveAction: @escaping () -> Void
     ) {
+        self.baseCollection = collection
         self.displayedCollection = collection
         self._selectedCollections = selection
-        self.saveAction = saveAction
-    }
-
-    init(
-        searchTerm: String,
-        selection: Binding<[PHAssetCollection]>,
-        saveAction: @escaping () -> Void
-    ) {
-        self.displayedCollection = .search
-        self._selectedCollections = selection
-        self.searchTerm = searchTerm
         self.saveAction = saveAction
     }
 
@@ -137,7 +127,7 @@ struct CollectionView: View {
             if navigator.isSearching {
                 self.displayedCollection = .search
             } else {
-                self.displayedCollection = nil
+                self.displayedCollection = baseCollection
             }
             reloadCollections()
         }
@@ -165,15 +155,23 @@ struct CollectionView: View {
             }
         } else {
             if displayedCollection == .search {
-                collections = PhotosLibrary.albums(containing: navigator.searchTerm)
-                if autoSelectFirstSearchResult, let collections, collections.count == 1 {
-                    switch collections.first {
-                    case .album(let album):
-                        if let album = album as? PHAssetCollection,
-                           !selectedCollections.isSelected(album) {
-                            selectedCollections.toggle(album, allowingMultiple: multipleAlbumSelection)
+                collections = PhotosLibrary.albumsAndFolders(
+                    matching: navigator.searchTerm,
+                    in: searchScope == .currentFolder ? baseCollection : nil
+                )
+                if autoSelectFirstSearchResult {
+                    // Folders cannot be saved to, so only the first album is auto selected
+                    let firstAlbum: PHAssetCollection? = (collections ?? [])
+                        .lazy
+                        .compactMap { collection -> PHAssetCollection? in
+                            if case .album(let album) = collection {
+                                return album as? PHAssetCollection
+                            }
+                            return nil
                         }
-                    default: break
+                        .first
+                    if let firstAlbum, !selectedCollections.isSelected(firstAlbum) {
+                        selectedCollections.toggle(firstAlbum, allowingMultiple: multipleAlbumSelection)
                     }
                 }
             } else {

--- a/Shared/Enums/SearchScope.swift
+++ b/Shared/Enums/SearchScope.swift
@@ -1,0 +1,5 @@
+
+enum SearchScope: String {
+    case currentFolder
+    case everywhere
+}

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -475,6 +475,22 @@
         }
       }
     },
+    "Settings.Appearance" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appearance"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外観"
+          }
+        }
+      }
+    },
     "Settings.AutoOpenKeyboard" : {
       "localizations" : {
         "en" : {
@@ -496,13 +512,29 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Automatically Select Search Result"
+            "value" : "Automatically Select First Search Result"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "検索結果が一件の場合自動的に選択"
+            "value" : "最初の検索結果を自動的に選択"
+          }
+        }
+      }
+    },
+    "Settings.Behaviors" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Behaviors"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動作"
           }
         }
       }
@@ -652,6 +684,86 @@
         }
       }
     },
+    "Settings.Search" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
+          }
+        }
+      }
+    },
+    "Settings.SearchIn" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search In"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索範囲"
+          }
+        }
+      }
+    },
+    "Settings.SearchIn.CurrentFolder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current Folder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のフォルダ"
+          }
+        }
+      }
+    },
+    "Settings.SearchIn.Everywhere" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Everywhere"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべての場所"
+          }
+        }
+      }
+    },
+    "Settings.Selection" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selection"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択"
+          }
+        }
+      }
+    },
     "Settings.Title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -691,13 +803,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Album Name"
+            "value" : "Album or Folder Name"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アルバム名"
+            "value" : "アルバムまたはフォルダ名"
           }
         }
       }


### PR DESCRIPTION
Fixes #11, fixes #9, fixes #8.

## Search
- **Token-based search**: the search term is split into tokens by whitespace (locale-aware, including full-width spaces), and any album or folder whose title contains at least one token is matched. Items whose title contains the entire search string are prioritized at the top of the results (e.g. searching `A B C` lists `A B C D` first, then `B`, then `C`), with each group sorted using `localizedStandardCompare`.
- **Folder search**: folders are now included in search results and sorted together with albums. Tapping a folder result navigates into it.
- **Search scope**: a new *Search In* picker in the main app's settings toggles between searching in the current folder (recursively) or searching everywhere.

## Auto select first search result
- The first album result is now automatically selected even when more than one result is found.
- Folders are excluded from auto selection, since photos can only be saved to albums.
- When multiple selection is disabled, the selected search result is deselected when it disappears from the results.

## Navigation fixes (#9)
- Clearing the search now restores the folder a pushed view was displaying, instead of resetting it to the top level.
- The pending debounce timer is invalidated when the search is cleared, so a stale timer can no longer resurrect an old search term.

## Settings rework
Settings in the main app (iOS and macOS) are now split into sections:
- **Appearance**: Display Mode, Enable Save Animation
- **Behaviors**: Save Recents, Auto Open Keyboard
- **Search**: Auto Select First Search Result, Search In
- **Selection**: Allow Multiple Selection, Allow No Selection

Localizations (en, ja) added for the new section headers and picker options, and the *Automatically Select First Search Result* label was updated to reflect the new behavior.

https://claude.ai/code/session_01C2mozvjW4zg4Wk7Jr5Fyy3

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2mozvjW4zg4Wk7Jr5Fyy3)_