### PR TITLE
Equalize internal margins in selected albums popover

### DIFF
--- a/Extension/Views/Collections/SelectedAlbumsView.swift
+++ b/Extension/Views/Collections/SelectedAlbumsView.swift
@@ -36,9 +36,11 @@ struct SelectedAlbumsView: View {
             .listRowInsets(.init(top: 6.0, leading: 20.0, bottom: 6.0, trailing: 20.0))
         }
         .listStyle(.plain)
+        // 14pt margin + 6pt row inset = 20pt, matching the rows' leading and trailing insets
+        .contentMargins(.vertical, 14.0, for: .scrollContent)
         .frame(
             minWidth: 280.0,
-            minHeight: min(CGFloat(max(selectedCollections.count, 1)) * 50.0 + 12.0, 312.0)
+            minHeight: min(CGFloat(max(selectedCollections.count, 1)) * 50.0 + 40.0, 340.0)
         )
         .onChange(of: selectedCollections) { _, newValue in
             if newValue.isEmpty {


### PR DESCRIPTION
## Summary
The selected albums popover in the share sheet had uneven internal margins: each row has 20pt leading/trailing insets, but the list had no vertical content margin, so the first and last rows sat nearly flush against the popover's top and bottom edges (only the 6pt row inset).

## Changes
- Added 14pt vertical content margins to the list in `SelectedAlbumsView` — combined with the existing 6pt row insets, this gives a 20pt inner margin all around, matching the sides.
- Adjusted the popover's minimum height estimate to account for the new vertical margins.

https://claude.ai/code/session_01Ur57dieHPufygeSNZc7TdW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ur57dieHPufygeSNZc7TdW)_